### PR TITLE
Feature/add login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,25 @@ import React from "react";
 import "./App.scss";
 import Sidebar from "./components/sidebar/Sidebar";
 import Chat from "./components/chat/Chat";
+import { useSelector } from "react-redux";
+import Login from "./components/login/Login";
 
 function App() {
+  // const user = useSelector((state) => state.user.user);
+  const user = null;
+
   return (
     <div className="App">
-      {/* Sidebar */}
-      <Sidebar />
-
-      {/* Chat */}
-      <Chat />
+      {user ? (
+        <>
+          <Sidebar />
+          <Chat />
+        </>
+      ) : (
+        <>
+          <Login />
+        </>
+      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,12 @@ import Sidebar from "./components/sidebar/Sidebar";
 import Chat from "./components/chat/Chat";
 import { useSelector } from "react-redux";
 import Login from "./components/login/Login";
+import { useAppSelector } from "./app/hooks";
 
 function App() {
-  // const user = useSelector((state) => state.user.user);
-  const user = null;
+  const user = useAppSelector((state) => state.user);
+  // const user = null;]
+  console.log(user);
 
   return (
     <div className="App">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,37 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./App.scss";
 import Sidebar from "./components/sidebar/Sidebar";
 import Chat from "./components/chat/Chat";
 import { useSelector } from "react-redux";
 import Login from "./components/login/Login";
-import { useAppSelector } from "./app/hooks";
+import { useAppDispatch, useAppSelector } from "./app/hooks";
+import { auth } from "./firebase";
+import { login, logout } from "./features/userSlice";
 
 function App() {
   const user = useAppSelector((state) => state.user);
   // const user = null;]
-  console.log(user);
+  // console.log(user);
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    auth.onAuthStateChanged((loginUser) => {
+      console.log(loginUser);
+      if (loginUser) {
+        dispatch(
+          login({
+            uid: loginUser.uid,
+            photo: loginUser.photoURL,
+            email: loginUser.email,
+            dipslayName: loginUser.displayName,
+          })
+        );
+      } else {
+        dispatch(logout());
+      }
+    });
+  }, [dispatch]);
 
   return (
     <div className="App">

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "./store";
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,5 +2,8 @@ import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "../features/userSlice";
 
 export const store = configureStore({
-    reducer: userReducer,
+  reducer: userReducer,
 });
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;

--- a/src/components/login/Login.scss
+++ b/src/components/login/Login.scss
@@ -1,0 +1,28 @@
+.login {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100vh;
+    gap: 30px;
+
+    button {
+        width: 200px;
+        background-color: #738adb;
+        color: #eff2f5;
+        font-weight: 800;
+        &:hover {
+            background-color: black;
+            color: #738adb;
+        }
+    }
+
+    .loginLogo {
+        img {
+            object-fit: cover;
+            height: 150px;
+        }
+    }
+}
+

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,15 +1,23 @@
 import React from "react";
 import "./Login.scss";
 import { Button } from "@mui/material";
+import { signInWithPopup } from "firebase/auth";
+import { auth, provider } from "../../firebase";
 
 const Login = () => {
+  const signIn = () => {
+    signInWithPopup(auth, provider).catch((err) => {
+      alert(err.message);
+    });
+  };
+
   return (
     <div className="login">
       <div className="loginLogo">
         <img src="./discordIcon.png" alt="" />
       </div>
 
-      <Button>Login</Button>
+      <Button onClick={signIn}>Login</Button>
     </div>
   );
 };

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "./Login.scss";
+import { Button } from "@mui/material";
+
+const Login = () => {
+  return (
+    <div className="login">
+      <div className="loginLogo">
+        <img src="./discordIcon.png" alt="" />
+      </div>
+
+      <Button>Login</Button>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/components/sidebar/Sidebar.scss
+++ b/src/components/sidebar/Sidebar.scss
@@ -82,6 +82,7 @@
                 
                 img {
                     width: 60px;
+                    border-radius: 50%;
                 }
 
                 .accountName {

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -6,8 +6,12 @@ import SidebarChannel from "./SidebarChannel";
 import MicIcon from "@mui/icons-material/Mic";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
 import SettingsIcon from "@mui/icons-material/Settings";
+import { auth } from "../../firebase";
+import { useAppSelector } from "../../app/hooks";
 
 const Sidebar = () => {
+  const user = useAppSelector((state) => state.user);
+
   return (
     <div className="sidebar">
       {/* sidebarLeft */}
@@ -45,10 +49,10 @@ const Sidebar = () => {
 
           <div className="sidebarFooter">
             <div className="sidebarAccount">
-              <img src="./icon.png" alt="" />
+              <img src={user?.photo} alt="" onClick={() => auth.signOut()} />
               <div className="accountName">
-                <h4>ShinCode</h4>
-                <span>#8162</span>
+                <h4>{user?.displayName}</h4>
+                <span>#{user?.uid.substring(0, 4)}</span>
               </div>
             </div>
 

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -19,4 +19,5 @@ export const userSlice = createSlice({
 });
 console.log(userSlice);
 
+export const { login, logout } = userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
## Why
Section 4 (32 - 37):

- URL: [Section - 37](https://www.udemy.com/course/discord-clone-udemy/learn/lecture/35746228#overview)

## What

- ログインコンポーネントの追加。
- useSelectorとuseDispatchの設定。
- Googleログイン機能追加。
- ログインしたユーザー情報をStoreに反映。
- ログアウト機能追加、ユーザー情報をUIに反映。

ログインページ：
![image](https://github.com/I-BIS-company/kawakami-discord-clone/assets/132991861/1114a694-b21e-470e-8d2e-8fc53cc08734)

ログイン機能：
![image](https://github.com/I-BIS-company/kawakami-discord-clone/assets/132991861/2c35622e-7a25-4fe1-a96e-51211b3710c3)

UIにユーザー情報(userID / Profile Photo)：
![image](https://github.com/I-BIS-company/kawakami-discord-clone/assets/132991861/3e065e1d-ab05-47e7-acda-5d13d6845146)
