### PR TITLE
Feature/add channel data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { auth } from "./firebase";
 import { login, logout } from "./features/userSlice";
 
 function App() {
-  const user = useAppSelector((state) => state.user);
+  const user = useAppSelector((state) => state.user.user);
   // const user = null;]
   // console.log(user);
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -6,3 +6,8 @@ export interface InitialUserState {
     displayName: string;
   };
 }
+
+export interface InitialChannelState {
+  channelId: string | null;
+  channelName: string | null;
+}

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,8 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "../features/userSlice";
+import channelReducer from "../features/channelSlice";
 
 export const store = configureStore({
-  reducer: userReducer,
+  reducer: {
+    user: userReducer,
+    channel: channelReducer,
+  },
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -6,12 +6,16 @@ import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
 import GifIcon from "@mui/icons-material/Gif";
 import EmojiEmotionsIcon from "@mui/icons-material/EmojiEmotions";
 import ChatMessage from "./ChatMessage";
+import { useAppSelector } from "../../app/hooks";
 
 const Chat = () => {
+  const channelName = useAppSelector((state) => state.channel.channelName);
+  // console.log(channelName);
+
   return (
     <div className="chat">
       {/* chatHeader */}
-      <ChatHeader />
+      <ChatHeader channelName={channelName} />
       {/* chatMessage */}
       <div className="chatMessage">
         <ChatMessage />

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -7,13 +7,18 @@ import SearchIcon from "@mui/icons-material/Search";
 import SendIcon from "@mui/icons-material/Send";
 import HelpIcon from "@mui/icons-material/Help";
 
-const ChatHeader = () => {
+type Props = {
+  channelName: string | null;
+};
+
+const ChatHeader = (props: Props) => {
+  const { channelName } = props;
   return (
     <div className="chatHeader">
       <div className="chatHeaderLeft">
         <h3>
           <span className="chatHeaderHash">#</span>
-          Udemy
+          {channelName}
         </h3>
       </div>
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ import { addDoc, collection } from "firebase/firestore";
 // import { collection, query } from "firebase/firestore/lite";
 
 const Sidebar = () => {
-  const user = useAppSelector((state) => state.user);
+  const user = useAppSelector((state) => state.user.user);
   const { documents: channels } = useCollection("channels");
 
   const addChannel = async () => {

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -9,11 +9,22 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import { auth, db } from "../../firebase";
 import { useAppSelector } from "../../app/hooks";
 import useCollection from "../../hooks/useCollection";
+import { addDoc, collection } from "firebase/firestore";
 // import { collection, query } from "firebase/firestore/lite";
 
 const Sidebar = () => {
   const user = useAppSelector((state) => state.user);
   const { documents: channels } = useCollection("channels");
+
+  const addChannel = async () => {
+    let channelName: string | null = prompt("Create a new channel");
+
+    if (channelName) {
+      await addDoc(collection(db, "channels"), {
+        channelName: channelName,
+      });
+    }
+  };
 
   return (
     <div className="sidebar">
@@ -40,7 +51,7 @@ const Sidebar = () => {
               <ExpandMoreIcon />
               <h4>Programming Channel</h4>
             </div>
-            <AddIcon className="sidebarAddIcon" />
+            <AddIcon className="sidebarAddIcon" onClick={() => addChannel()} />
           </div>
 
           <div className="sidebarChannelList">

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -8,37 +8,12 @@ import HeadphonesIcon from "@mui/icons-material/Headphones";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { auth, db } from "../../firebase";
 import { useAppSelector } from "../../app/hooks";
+import useCollection from "../../hooks/useCollection";
 // import { collection, query } from "firebase/firestore/lite";
-import {
-  onSnapshot,
-  collection,
-  query,
-  DocumentData,
-} from "firebase/firestore";
-
-interface Channel {
-  id: string;
-  channel: DocumentData;
-}
 
 const Sidebar = () => {
-  const [channels, setChannels] = useState<Channel[]>([]);
-
   const user = useAppSelector((state) => state.user);
-  const q = query(collection(db, "channels"));
-
-  useEffect(() => {
-    onSnapshot(q, (querySnapshot) => {
-      const channelsResults: Channel[] = [];
-      querySnapshot.docs.forEach((doc) =>
-        channelsResults.push({
-          id: doc.id,
-          channel: doc.data(),
-        })
-      );
-      setChannels(channelsResults);
-    });
-  }, []);
+  const { documents: channels } = useCollection("channels");
 
   return (
     <div className="sidebar">

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./Sidebar.scss";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
@@ -6,11 +6,21 @@ import SidebarChannel from "./SidebarChannel";
 import MicIcon from "@mui/icons-material/Mic";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { auth } from "../../firebase";
+import { auth, db } from "../../firebase";
 import { useAppSelector } from "../../app/hooks";
+// import { collection, query } from "firebase/firestore/lite";
+import { onSnapshot, collection, query } from "firebase/firestore";
 
 const Sidebar = () => {
   const user = useAppSelector((state) => state.user);
+  const q = query(collection(db, "channels"));
+
+  useEffect(() => {
+    onSnapshot(q, (querySnapshot) => {
+      const channelsResults = [];
+      querySnapshot.docs.forEach((doc) => console.log(doc));
+    });
+  }, []);
 
   return (
     <div className="sidebar">

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import "./Sidebar.scss";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
@@ -9,16 +9,34 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import { auth, db } from "../../firebase";
 import { useAppSelector } from "../../app/hooks";
 // import { collection, query } from "firebase/firestore/lite";
-import { onSnapshot, collection, query } from "firebase/firestore";
+import {
+  onSnapshot,
+  collection,
+  query,
+  DocumentData,
+} from "firebase/firestore";
+
+interface Channel {
+  id: string;
+  channel: DocumentData;
+}
 
 const Sidebar = () => {
+  const [channels, setChannels] = useState<Channel[]>([]);
+
   const user = useAppSelector((state) => state.user);
   const q = query(collection(db, "channels"));
 
   useEffect(() => {
     onSnapshot(q, (querySnapshot) => {
-      const channelsResults = [];
-      querySnapshot.docs.forEach((doc) => console.log(doc));
+      const channelsResults: Channel[] = [];
+      querySnapshot.docs.forEach((doc) =>
+        channelsResults.push({
+          id: doc.id,
+          channel: doc.data(),
+        })
+      );
+      setChannels(channelsResults);
     });
   }, []);
 
@@ -51,10 +69,17 @@ const Sidebar = () => {
           </div>
 
           <div className="sidebarChannelList">
+            {channels.map((channel) => (
+              <SidebarChannel
+                channel={channel}
+                id={channel.id}
+                key={channel.id}
+              />
+            ))}
+            {/* <SidebarChannel />
             <SidebarChannel />
             <SidebarChannel />
-            <SidebarChannel />
-            <SidebarChannel />
+            <SidebarChannel /> */}
           </div>
 
           <div className="sidebarFooter">

--- a/src/components/sidebar/SidebarChannel.tsx
+++ b/src/components/sidebar/SidebarChannel.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import "./SidebarChannel.scss";
 import { DocumentData } from "firebase/firestore";
+import { useAppDispatch } from "../../app/hooks";
+import { setChannelInfo } from "../../features/channelSlice";
 
 type Props = {
   id: string;
@@ -9,10 +11,20 @@ type Props = {
 
 const SidebarChannel = (props: Props) => {
   const { id, channel } = props;
-  // console.log(channel);
+  const dispatch = useAppDispatch();
 
   return (
-    <div className="sidebarChannel">
+    <div
+      className="sidebarChannel"
+      onClick={() =>
+        dispatch(
+          setChannelInfo({
+            channelId: id,
+            channelName: channel.channel.channelName,
+          })
+        )
+      }
+    >
       <h4>
         <span className="sidebarChannelHash">#</span>
         {channel.channel.channelName}

--- a/src/components/sidebar/SidebarChannel.tsx
+++ b/src/components/sidebar/SidebarChannel.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 import "./SidebarChannel.scss";
+import { DocumentData } from "firebase/firestore";
 
-const SidebarChannel = () => {
+type Props = {
+  id: string;
+  channel: DocumentData;
+};
+
+const SidebarChannel = (props: Props) => {
+  const { id, channel } = props;
+  // console.log(channel);
+
   return (
     <div className="sidebarChannel">
       <h4>
         <span className="sidebarChannelHash">#</span>
-        Udemy
+        {channel.channel.channelName}
       </h4>
     </div>
   );

--- a/src/features/channelSlice.ts
+++ b/src/features/channelSlice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { InitialChannelState } from "../Types";
+
+const initialState: InitialChannelState = {
+  channelId: null,
+  channelName: null,
+};
+
+export const channelSlice = createSlice({
+  name: "channel",
+  initialState,
+  reducers: {
+    setChannelInfo: (state, action) => {
+      state.channelId = action.payload.channelId;
+      state.channelName = action.payload.channelName;
+    },
+  },
+});
+
+export const { setChannelInfo } = channelSlice.actions;
+export default channelSlice.reducer;

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -17,7 +17,7 @@ export const userSlice = createSlice({
     },
   },
 });
-console.log(userSlice);
+// console.log(userSlice);
 
 export const { login, logout } = userSlice.actions;
 export default userSlice.reducer;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore/lite";
+import { getFirestore } from "firebase/firestore";
 import { GoogleAuthProvider, getAuth } from "firebase/auth";
 
 const firebaseConfig = {
@@ -8,7 +8,7 @@ const firebaseConfig = {
   projectId: "discord-clone-udemy-5bb94",
   storageBucket: "discord-clone-udemy-5bb94.appspot.com",
   messagingSenderId: "537018561608",
-  appId: "1:537018561608:web:1d110a19ce49c5fffc147d"
+  appId: "1:537018561608:web:1d110a19ce49c5fffc147d",
 };
 
 const app = initializeApp(firebaseConfig);
@@ -16,4 +16,4 @@ const db = getFirestore(app);
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
 
-export { auth, provider, db }
+export { auth, provider, db };

--- a/src/hooks/useCollection.tsx
+++ b/src/hooks/useCollection.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import {
+  onSnapshot,
+  collection,
+  query,
+  DocumentData,
+  CollectionReference,
+  Query,
+} from "firebase/firestore";
+import { db } from "../firebase";
+
+interface Channels {
+  id: string;
+  channel: DocumentData;
+}
+
+const useCollection = (data: string) => {
+  const [documents, setDocuments] = useState<Channels[]>([]);
+  const collectionRef: Query<DocumentData> = query(collection(db, data));
+
+  useEffect(() => {
+    onSnapshot(collectionRef, (querySnapshot) => {
+      const channelsResults: Channels[] = [];
+      querySnapshot.docs.forEach((doc) =>
+        channelsResults.push({
+          id: doc.id,
+          channel: doc.data(),
+        })
+      );
+      setDocuments(channelsResults);
+    });
+  }, []);
+
+  return { documents };
+};
+
+export default useCollection;


### PR DESCRIPTION
## Why
Section 5 (38 - 47):

- URL: [Section 5 (47)](https://www.udemy.com/course/discord-clone-udemy/learn/lecture/35875316#overview) 

## What

- CloudFirestoreからリアルタイムでデータ取得の設定。(onSnapshot)
- CloudDBにあるデータをDiscordチャンネルに出力。
- リアルタイムのデータ取得関数をカスタムフック化。
- チャンネル作成機能追加。
- チャンネル切り替えの情報をチャットボックスのヘッダーに反映。

追加機能:
![DiscordChannelFunction](https://github.com/I-BIS-company/kawakami-discord-clone/assets/132991861/3392188b-5aa3-4738-97d9-01c03bf90473)
