### PR TITLE
Fix chat layout bug

### DIFF
--- a/src/components/chat/Chat.scss
+++ b/src/components/chat/Chat.scss
@@ -3,9 +3,11 @@
     flex-direction: column;
     flex-grow: 1;
     background-color: #393943;
+    height: 100vh;
 
     .chatMessage {
-        flex-grow: 1;
+        height: 100vh;
+        overflow-y: scroll;
     }
 
     .chatInput {


### PR DESCRIPTION
## Why
Section 5 (53)

- URL: [Section 5 - 53](https://www.udemy.com/course/discord-clone-udemy/learn/lecture/36125104#notes)

## What

- チャットボックスに投稿しすぎるとレイアウトがずれるバグの修正。
- チャットボックスにスクロールバー追加。

修正前：
![image](https://github.com/I-BIS-company/training-daily-report/assets/132991861/ca8c349f-b854-4ed6-ab35-bfd56059d27e)

修正後：
![image](https://github.com/I-BIS-company/training-daily-report/assets/132991861/fd0cad94-c5c9-41a2-b488-17a3453fdb09)